### PR TITLE
Update GHA to publish to gh-pages branch

### DIFF
--- a/.github/workflows/render-specs.yml
+++ b/.github/workflows/render-specs.yml
@@ -1,33 +1,30 @@
-name: spec-up-render
+# This is a basic workflow to help you get started with Actions
 
+name: Build Spec
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
 on:
   push:
     branches:
       - main
 
 jobs:
-  build-and-deploy-spec:
+  build_spec:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
-        with:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v2
+      with:
           persist-credentials: false
 
-      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
-        run: |
+    - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+      run: |
           npm install
-          npm run render
-          rm -rf node_modules
-          
-      - name: Prepare Site
-        run: |
-          make deploy
-
-      - name: Deploy Github Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
-          allow_empty_commit: true
-          force_orphan: true
+          npm run spec:render
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.3
+      with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages # The branch the action should deploy to.
+          folder: . # The folder the action should deploy.


### PR DESCRIPTION
In theory, should address #8 . Publishing will go to the gh-pages branch, and gh-pages publishing will trigger on that.
