### PR TITLE
Change the separator for a sub-namespace to . from :

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,10 @@ published from there. If there is a way to .gitignore the `index.html` in the ma
 
 Hint: One way to revert the updated `docs/index.html` before doing a commit, is to run: `git checkout -- docs/index.html`
 
-### Editing the spec in the cloud with Gitpod
+## Editing the spec in the cloud with Gitpod
 
 An alternative way to contribute to the specification, without any local installation, is to use [Gitpod](https://www.gitpod.io/).
+
 - Fork the repo. 
 - Open `https://gitpod.io/#https://github.com/YOUR_FORK_USER/indy-did-method`
 - Register with Gitpod using your GitHub Account and provide `public_repo` permissions in order to commit to your fork from Gitpod.

--- a/spec/10_did_operations.md
+++ b/spec/10_did_operations.md
@@ -8,7 +8,7 @@ Creation of a `did:indy` DID is performed by an authorized entity executing a `N
 
 - A `did:indy` DID MUST be self-certifying by having the namespace identifier component of the DID (last element) derived from the initial public key of the DID, as follows:
 
-    - For an Ed25519 key: Convert into Base58char the first 16 bytes of the 256 bit public key (verkey).
+  - For an Ed25519 key: Convert into Base58char the first 16 bytes of the 256 bit public key (verkey).
 
 - The Indy ledger MUST verify the relationship between the namespace identifier component of the DID and the initial public key (verkey). If the relationship between the data elements fails verification, the transaction MUST be rejected and an error returned to the client.
 
@@ -76,6 +76,7 @@ The base DIDDoc template is static text that forms a JSON structure. To transfor
 Assuming values `sovrin` for the `namespace`, `123456` for `dest` and `789abc` for the `verkey` the resulting JSON DIDDoc would be:
 
 ::: example Base DIDDoc sovrin example
+
 ```json
 {
   "id": "did:indy:sovrin:123456",
@@ -98,6 +99,7 @@ Assuming values `sovrin` for the `namespace`, `123456` for `dest` and `789abc` f
 An example of a [[ref: NYM]]'s extended DIDDoc handling is provided below. In the example below, the `diddocContent` item adds a DIDcomm Messaging service endpoint to the resolved DIDDoc. Note that in the example, an `@context` item is included in the `diddocContent`, which causes the result DIDDoc to be a JSON-LD document, rather than plain JSON.
 
 ::: example Extended DIDDoc Item example
+
 ```json
 "diddocContent" : {
     "@context" : [ 
@@ -115,11 +117,13 @@ An example of a [[ref: NYM]]'s extended DIDDoc handling is provided below. In th
     ]
   }
 ```
+
 :::
 
 Applying the DIDDoc assembly rules to the example above produces the following assembled, valid JSON-LD DIDDoc:
 
 ::: example assembled Extended JSON-LD DIDDoc Item  example
+
 ```json
 {
   "@context": [
@@ -148,6 +152,7 @@ Applying the DIDDoc assembly rules to the example above produces the following a
   ]
 }
 ```
+
 :::
 
 #### Key Agreement

--- a/spec/11_did_indy_did_component_syntax.md
+++ b/spec/11_did_indy_did_component_syntax.md
@@ -5,17 +5,17 @@ The following sections provide the syntax and ABNF for the two variable componen
 
 ### `did:indy` DID Namespace Syntax
 
-The `did:indy` DID Namespace component MUST include a primary, human-friendly name of the Indy network instance, MAY include an optional ":" separator and subspace, human-friendly name, and MUST include a trailing ":" separator. The subspace name is used to identify an Indy instance related to the primary instance, such as the primary network's test or development instance. The ABNF for the namespace component is:
+The `did:indy` DID Namespace component MUST include a primary, human-friendly name of the Indy network instance, MAY include an optional "." separator and subspace, human-friendly name, and MUST include a trailing ":" separator. The subspace name is used to identify an Indy instance related to the primary instance, such as the primary network's test or development instance. The ABNF for the namespace component is:
 
-    namespace     = namestring (":" namestring) ":"
+    namespace     = namestring ("." namestring) ":"
     namestring    = ALPHA *(ALPHA / DIGIT / "_" / "-")
 
-The namespace is set by the operator of the network. Although that could lead to namespace collisions, our 
+The namespace is set by the operator of the network. Although that could lead to namespace collisions, our
 [assumption about the expected number of Indy instances](#assumption-number-of-indy-instances) (low 100s at the most) eliminates that as a concern.
 
 ### `did:indy` DID Namespace Identifier Syntax
 
-The namespace identifer is an identifier within the namespace of a Hyperledger Indy network that is unique for that namespace.
+The namespace identifier is an identifier within the namespace of a Hyperledger Indy network that is unique for that namespace.
 
 The namespace identifier (NSID) is defined by the following ABNF:
 

--- a/spec/13_security_considerations.md
+++ b/spec/13_security_considerations.md
@@ -13,25 +13,26 @@ Review https://datatracker.ietf.org/doc/html/rfc3552 and ensure documentation is
 :::
 
 - The Security Considerations section MUST document the following forms of attack for the DID operations defined in the DID method specification: eavesdropping, replay, message insertion, deletion, modification, denial of service, storage or network amplification, and man-in-the-middle. Other known forms of attack SHOULD also be documented.
-    - eavesdropping
-        - Doesn't matter -- data written is public
-    - replay
-        - Nonce included -- prevents replay
-    - message insertion
-        - Not possible
-    - deletion
-        - Not possible
-    - modification
-        - Consensus prevents
-    - denial of service
-        - Separate interfaces to prevent loss of node-to-node communications
-    - storage or network amplification
-        - Definition: https://github.com/w3c/did-core/pull/730/files
-    - man-in-the-middle
-        - Authorization prevents
+  
+  - eavesdropping
+    - Doesn't matter -- data written is public
+  - replay
+    - Nonce included -- prevents replay
+  - message insertion
+    - Not possible
+  - deletion
+    - Not possible
+  - modification
+    - Consensus prevents
+  - denial of service
+    - Separate interfaces to prevent loss of node-to-node communications
+  - storage or network amplification
+    - Definition: https://github.com/w3c/did-core/pull/730/files
+  - man-in-the-middle
+    - Authorization prevents
 
-::: todo document attack mitigations
-Document each attack mitigations; add others that might be relevant.
+::: todo document mitigations for the forms of attack
+Document mitigations for each the forms of attack; add others that might be relevant.
 :::
 
 - The Security Considerations section MUST discuss residual risks, such as the risks from compromise in a related protocol, incorrect implementation, or cipher after threat mitigation was deployed.
@@ -47,20 +48,21 @@ Brief review of the write operations -- DID Controller must sign operation, as n
 :::
 
 - If authentication is involved, particularly user-host authentication, the security characteristics of the authentication method MUST be clearly documented.
-    - No user-host authentication is used. The appropriate signatures are needed on write transactions, where the DIDs and verkeys of the signatories must be one the ledger.
+  - No user-host authentication is used. The appropriate signatures are needed on write transactions, where the DIDs and verkeys of the signatories must be one the ledger.
 
 ::: todo expand authentication
 Expand
 :::
 
 - The Security Considerations section MUST discuss the policy mechanism by which DIDs are proven to be uniquely assigned.
-    - DIDs are self-certifying, derived from the initial verkey of an ED25519 key pair, which makes them extremely likely to be unique. Any attempt to write the same DID would only work if the signature matched (e.g. if the seed to create the DID had been lost so the literal same DID was attempted to be written), which would result in no change to the ledger, and goes against assumption of the DID Controller not protecting their seed/private key.
+  - DIDs are self-certifying, derived from the initial verkey of an ED25519 key pair, which makes them extremely likely to be unique. Any attempt to write the same DID would only work if the signature matched (e.g. if the seed to create the DID had been lost so the literal same DID was attempted to be written), which would result in no change to the ledger, and goes against assumption of the DID Controller not protecting their seed/private key.
 
 ::: todo expand security considerations
 Expand
 :::
+
 - Method-specific endpoint authentication MUST be discussed. Where DID methods make use of DLTs with varying network topology, sometimes offered as light node or thin client implementations to reduce required computing resources, the security assumptions of the topology available to implementations of the DID method MUST be discussed.
-    - No endpoint authentication is used.
+  - No endpoint authentication is used.
 
 ::: todo expand method-specific endpoint authentication
 Expand
@@ -73,8 +75,8 @@ Expand
 :::
 
 - Data which is to be held secret (keying material, random seeds, and so on) SHOULD be clearly labeled.
-    - No ledger data needs to be kept secret. The private keys associated with the public keys written to the ledger must be kept secret.
-    - The seed used for private key generation
+  - No ledger data needs to be kept secret. The private keys associated with the public keys written to the ledger must be kept secret.
+  - The seed used for private key generation
 
 ::: todo expand secret data labeling
 Expand

--- a/spec/14_privacy_considerations.md
+++ b/spec/14_privacy_considerations.md
@@ -1,5 +1,4 @@
 
-
 ## Privacy Considerations
 
 Given that Indy is a publicly readable, immutable ledger, no personally identifiable information, including DIDs where a person is the DID Subject, should be placed on the network.
@@ -9,15 +8,15 @@ Given that Indy is a publicly readable, immutable ledger, no personally identifi
 The requirements for all DID method specifications when authoring the Privacy Considerations section are:
 
 - The DID method specification's Privacy Considerations section MUST discuss any subsection of [Section 5 of RFC6973](https://tools.ietf.org/html/rfc6973#section-5) that could apply in a method-specific manner. The subsections to consider are: surveillance, stored data compromise, unsolicited traffic, misattribution, correlation, identification, secondary use, disclosure, and exclusion.
-    - surveillance
-    - stored data compromise
-    - unsolicited traffic
-    - misattribution
-    - correlation
-    - identification
-    - secondary use
-    - disclosure
-    - exclusion
+  - surveillance
+  - stored data compromise
+  - unsolicited traffic
+  - misattribution
+  - correlation
+  - identification
+  - secondary use
+  - disclosure
+  - exclusion
 
 ::: todo add responses for privacy considerations
 Need responses to each section

--- a/spec/15_future_directions.md
+++ b/spec/15_future_directions.md
@@ -18,4 +18,4 @@ Some consideration was given to the idea of allowing network discovery by regist
 
 ### Other Signature Schemes
 
-Indy implicitly uses the ED25519 Signature scheme for the `verkey`. We recommend that the [[ref: NYM]]s be evolved to explcitly state the signature scheme so that other signature key schemes can be used on Indy networks.
+Indy implicitly uses the ED25519 Signature scheme for the `verkey`. We recommend that the [[ref: NYM]]s be evolved to explicitly state the signature scheme so that other signature key schemes can be used on Indy networks.

--- a/spec/6_motivation_and_assumptions.md
+++ b/spec/6_motivation_and_assumptions.md
@@ -2,7 +2,7 @@
 
 ### Assumption: Number of Indy Instances
 
-We are anticipating that there will be at most on the order of "low hundreds" of Indy network instances, with the potential for several (usually 3) subnamespaces per network instance for production, test (staging), and development deployments. This assumption is based on the likelihood of their being some (likely small) number of global Indy instances, and some number of national Indy instances. Assuming at most one per country, we would have around 200-300 total, leading to the anticipated maximum of "low hundreds" of Indy network instances.
+We are anticipating that there will be at most on the order of "low hundreds" of Indy network instances, with the potential for several (usually 3) sub-namespaces per network instance for production, test (staging), and development deployments. This assumption is based on the likelihood of their being some (likely small) number of global Indy instances, and some number of national Indy instances. Assuming at most one per country, we would have around 200-300 total, leading to the anticipated maximum of "low hundreds" of Indy network instances.
 
 ### Including a Network-specific Identifier
 

--- a/spec/7_indy_did_method_identifiers.md
+++ b/spec/7_indy_did_method_identifiers.md
@@ -4,9 +4,9 @@ The did:indy Method DID identifier has four components that are concatonated to 
 
 - **DID**: the hardcoded string `did:` to indicate the identifier is a DID
 - **DID Indy Method**: the hardcoded string `indy:` indicating that the identifier uses this DID Method specification.
-- **DID Indy Namespace**: a string that identifies the name of the primary Indy ledger, followed by a `:`. The namespace string may optionally have a secondary ledger name prefixed by a `:` following the primary name. If there is no secondary ledger element, the DID resides on the primary ledger, else it resides on the secondary ledger. By convention, the primary is a production ledger while the secondary ledgers are non-production ledgers (e.g. staging, test, development) associated with the primary ledger. Examples include, `sovrin`, `sovrin:staging` and `idunion`.
-- **Namespace Identifier**: a self-certifying identifier unique to the given DID Indy namespace. To be 
-  self-certifying the identifier must be derived from the initial verkey associated with the identifier. See the 
+- **DID Indy Namespace**: a string that identifies the name of the primary Indy ledger, followed by a `:`. The namespace string may optionally have a secondary ledger name prefixed by a `.`(period). following the primary name. If there is no secondary ledger element, the DID resides on the primary ledger, else it resides on the secondary ledger. By convention, the primary is a production ledger while the secondary ledgers are non-production ledgers (e.g. staging, test, development) associated with the primary ledger. Examples include, `sovrin`, `sovrin.staging` and `idunion`.
+- **Namespace Identifier**: a self-certifying identifier unique to the given DID Indy namespace. To be
+  self-certifying the identifier must be derived from the initial verkey associated with the identifier. See the
   [DID Creation](#creation) section of this document for the derivation details.
 
 The components are assembled as follows:
@@ -18,6 +18,6 @@ Some examples of `did:indy` DID Method identifiers are:
 * A DID written to the Sovrin MainNet ledger:
     * `did:indy:sovrin:7Tqg6BwSSWapxgUDm9KKgg`
 * A DID written to the Sovrin StagingNet ledger:
-    * `did:indy:sovrin:staging:6cgbu8ZPoWTnR5Rv5JcSMB`
+    * `did:indy:sovrin.staging:6cgbu8ZPoWTnR5Rv5JcSMB`
 * A DID on the IDUnion Test ledger:
-    * `did:indy:idunion:test:2MZYuPv2Km7Q1eD4GCsSb6`
+    * `did:indy:idunion.test:2MZYuPv2Km7Q1eD4GCsSb6`

--- a/spec/8_other_indy_ledger_object_identifiers.md
+++ b/spec/8_other_indy_ledger_object_identifiers.md
@@ -70,14 +70,15 @@ DID URL: [did:indy:sovrin:5nDyJVP1NrcPAttP3xwMB9/REV_REG_ENTRY/npdb/TAG1](https:
 The DID URL resolution response depends on the query parameters used, as follows:
 
 - `?versionId=<timestamp>`
-    - Response is the same as the Indy Node [GET_REVOC_REG Txn](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#get-revoc-reg)
-    - If the parameter is left off the current time is used for the timestamp.
+  - Response is the same as the Indy Node [GET_REVOC_REG Txn](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#get-revoc-reg)
+  - If the parameter is left off the current time is used for the timestamp.
 - `?from=<timestamp>&to=<timestamp>`
-    - Response is the same as the Indy Node [GET_REVOC_REG_DELTA Txn](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#get-revoc-reg-delta)
-    - As noted in the transaction documentation, the from parameter is optional.
-    - If the `to` parameter is left off the current time is used for the `to` timestamp.
+  - Response is the same as the Indy Node [GET_REVOC_REG_DELTA Txn](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#get-revoc-reg-delta)
+  - As noted in the transaction documentation, the from parameter is optional.
+  - If the `to` parameter is left off the current time is used for the `to` timestamp.
 
 Existing Identifier: `5:5nDyJVP1NrcPAttP3xwMB9:4:5nDyJVP1NrcPAttP3xwMB9:3:CL:56495:npdb:CL_ACCUM:TAG1`
+
 - `5` is the enumerated object type
 - The remainder of the identifier is the identifier for the applicable Revocation Registry
 

--- a/spec/9_finding_indy_ledgers.md
+++ b/spec/9_finding_indy_ledgers.md
@@ -1,6 +1,6 @@
 ## Finding Indy Ledgers
 
-To connect and read or write from a Hyperledger Indy network instance, a client must have the configuration file (in Indy, called the "gensis" file) for the network. Given a `did:indy` DID (e.g. `did:indy:<namespace>:<namespace identifier>`), the Indy network instance on which the DID resides is known. However, there remains a challenge for the entity interested in resolving the DID&mdash;finding the genesis file for that network instance. The following documents two mechanisms resolvers can use to access required genesis files.
+To connect and read or write from a Hyperledger Indy network instance, a client must have the configuration file (in Indy, called the "genesis" file) for the network. Given a `did:indy` DID (e.g. `did:indy:<namespace>:<namespace identifier>`), the Indy network instance on which the DID resides is known. However, there remains a challenge for the entity interested in resolving the DID&mdash;finding the genesis file for that network instance. The following documents two mechanisms resolvers can use to access required genesis files.
 
 ### Static
 
@@ -38,7 +38,7 @@ The security policy of the client (and perhaps the user of the client) might giv
 
 Each contributing network instance operator maintains copies of their genesis files and supporting documents in the GitHub repo by submitting Pull Requests (PRs) to the repo. The community selected repo maintainers are expected to merge PRs with limited review based on their knowledge of the network operators. Their focus is not to provide editorial oversight but only to:
 
-- prevent updates to a network's gensis file by other than known operator of the network, and
+- prevent updates to a network's genesis file by other than known operator of the network, and
 - prevent badly formatted genesis files from being added to the repository.
 
 The maintainers are authorized to submit PRs to remove "bad actor" network folders based on notifications from the community and followup verification.


### PR DESCRIPTION
Per #22 -- a PR that proposes changing the separator within the namespace component to be a "." instead of a ":", so that regex's are easier for extracting the components of a DID -- the "did" prefix, the "indy" method, the namespace and the namespace identifier. With this change, for each there is exactly one ":" between each of the 4 segments of the identifier (vs. 4 or 5 depending on the ledger name).

Per the [DID Spec identifier syntax rules](https://www.w3.org/TR/did-core/#did-syntax), the "." is permitted.  Alternatives are "-" and "_", but I think "." makes the most sense.


