### PR TITLE
Remove ATTRIB URL and note the deprecation of ATTRIB usage

### DIFF
--- a/spec/10_did_operations.md
+++ b/spec/10_did_operations.md
@@ -43,6 +43,7 @@ The following are the steps for assembling a DIDDoc from its inputs.
 2. The Indy network instance `namespace`, the [[ref: NYM]] `dest` and the [[ref: NYM]] `verkey` items are merged into a text template to produce a base DIDDoc.
     1. See the template in the [Base DIDDoc Template](#base-diddoc-template) section of this document.
     2. If there is no `diddocContent` item in the [[ref: NYM]], assembly is complete; return the DIDDoc and a success status.
+       1. For backwards compatibility to the `did:sov` DID Method, if there is no `diddocContent` iten, a client DID resolver **MAY** attempt to read the `endpoint` ATTRIB object related to the DID and add it to the DIDDoc. See the [Endpoint ATTRIB section (below)](#the-%22endpoint%22-attrib) for more details.
 3. If the `diddocContent` item is included in the [[ref: NYM]] is verified and merged into the DIDDoc.
     1. The `diddocContent` item MUST NOT have an `id` item. If found, exit the assembly process, returning an error.
     2. If the `diddocContent` item contains a `@context` item, the DIDDoc is assumed to be JSON-LD, and the `@context` element MUST include the current DID Core JSON-LD context. If it does not, exit the assmebly process and return an error.
@@ -164,7 +165,7 @@ By default there is no key agreement section in an assembled DIDDoc. If the DID 
 
 Prior to the definition of this DID Method, a convention on Indy ledgers to associate an endpoint to a [[ref: NYM]] involved adding an [[ref: ATTRIB]] ledger object with a `raw` value of contain the JSON for a name-value pair of `endpoint` and a URL endpoint, often an IP address.
 
-We recommend that anyone that is using that format prior to the availability of the `did:indy` DID Method update their [[ref: NYM]] on the ledger to use the `diddocContent` item as soon as possible.
+We strongly encourage anyone using the "ATTRIB endpoint" convention to update their [[ref: NYM]] on the ledger to use the `diddocContent` item as soon as possible, as the [[ref: ATTRIB]] is deprecated as of the availability of the `did:indy` DID Method.
 
 If a client retrieves a [[ref: NYM]] that has a `diddocContent` data element, the client should assume that the DID Controller has made the [[ref: ATTRIB]] (if any) obsolete and the client SHOULD NOT retrieve the [[ref: ATTRIB]] associated with the DID.
 

--- a/spec/10_did_operations.md
+++ b/spec/10_did_operations.md
@@ -165,7 +165,7 @@ By default there is no key agreement section in an assembled DIDDoc. If the DID 
 
 Prior to the definition of this DID Method, a convention on Indy ledgers to associate an endpoint to a [[ref: NYM]] involved adding an [[ref: ATTRIB]] ledger object with a `raw` value of contain the JSON for a name-value pair of `endpoint` and a URL endpoint, often an IP address.
 
-We strongly encourage anyone using the "ATTRIB endpoint" convention to update their [[ref: NYM]] on the ledger to use the `diddocContent` item as soon as possible, as the [[ref: ATTRIB]] is deprecated as of the availability of the `did:indy` DID Method.
+We strongly encourage anyone using the "ATTRIB endpoint" convention to update their [[ref: NYM]] on the ledger to use the `diddocContent` item as soon as possible, as the [[ref: ATTRIB]] is deprecated with the introduction of the `did:indy` DID Method.
 
 If a client retrieves a [[ref: NYM]] that has a `diddocContent` data element, the client should assume that the DID Controller has made the [[ref: ATTRIB]] (if any) obsolete and the client SHOULD NOT retrieve the [[ref: ATTRIB]] associated with the DID.
 

--- a/spec/10_did_operations.md
+++ b/spec/10_did_operations.md
@@ -43,7 +43,7 @@ The following are the steps for assembling a DIDDoc from its inputs.
 2. The Indy network instance `namespace`, the [[ref: NYM]] `dest` and the [[ref: NYM]] `verkey` items are merged into a text template to produce a base DIDDoc.
     1. See the template in the [Base DIDDoc Template](#base-diddoc-template) section of this document.
     2. If there is no `diddocContent` item in the [[ref: NYM]], assembly is complete; return the DIDDoc and a success status.
-       1. For backwards compatibility to the `did:sov` DID Method, if there is no `diddocContent` iten, a client DID resolver **MAY** attempt to read the `endpoint` ATTRIB object related to the DID and add it to the DIDDoc. See the [Endpoint ATTRIB section (below)](#the-%22endpoint%22-attrib) for more details.
+       1. For backwards compatibility to the `did:sov` DID Method, if there is no `diddocContent` item, a client DID resolver **MAY** attempt to read the `endpoint` ATTRIB object related to the DID and add it to the DIDDoc. See the [Endpoint ATTRIB section (below)](#the-%22endpoint%22-attrib) for more details.
 3. If the `diddocContent` item is included in the [[ref: NYM]] is verified and merged into the DIDDoc.
     1. The `diddocContent` item MUST NOT have an `id` item. If found, exit the assembly process, returning an error.
     2. If the `diddocContent` item contains a `@context` item, the DIDDoc is assumed to be JSON-LD, and the `@context` element MUST include the current DID Core JSON-LD context. If it does not, exit the assmebly process and return an error.

--- a/spec/3_indy_ledger_object_glossary.md
+++ b/spec/3_indy_ledger_object_glossary.md
@@ -15,13 +15,19 @@ Instances of Hyperledger Indy networks persist different kind of (internal) data
 finalize
 :::
 
-[[def: ATTRIB]]
+[[def: ATTRIB]] - **Deprecated**
 
-~ A Hyperledger Indy ATTRIB (short for "attribute") object extends a specific DID (respectively the [[ref: NYM]]) of its owner with further information (attributes) and can be [read](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#get-attrib) from a Hyperledger Indy Node by any client. An ATTRIB object can only be [written](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#attrib) to a Hyperledger Indy network by an owner of the DID on that network.
+~ A Hyperledger Indy ATTRIB (short for "attribute") object extends a specific DID (also known as [[ref: NYM]]) of its owner with further information (attributes) and can be [read](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#get-attrib) from a Hyperledger Indy Node by any client. An ATTRIB object can only be [written](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#attrib) to a Hyperledger Indy network by an owner of the DID on that network.
 
-::: todo finalize ATTRIB glossary entry
-finalize
-:::
+~ The use of ATTRIB is **deprecated** with the introduction of the `did:indy`
+DID Method. The only common use of ATTRIBs in Hyperledger Indy prior to
+`did:indy` was to define DIDDoc service endpoints for a DID. Since with
+`did:indy` such a service endpoint can be added directly to the DID (along with
+any other DIDDoc data) there is no need to continue the use of the older ATTRIB
+`endpoint` convention. While a Hyperledger Indy client (such as [[ref: Indy
+VDR]]) MAY continue to try to resolve an `endpoint` ATTRIB when there is no
+DIDDoc content in a resolved DID, the ongoing practice of using an ATTRIB for
+that or any other purpose is discouraged.
 
 [[def: SCHEMA]]
 
@@ -59,3 +65,8 @@ finalize
 ~ Any REV_REG_ENTRY condensed with further required information can be [read](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#get-revoc-reg-delta) by any Hyperledger Indy client.
 
 ~ Further details about Hyperledger Indy's revocation process can be found [here](https://hyperledger-indy.readthedocs.io/projects/hipe/en/latest/text/0011-cred-revocation/README.html).
+
+[[def: Indy VDR]]
+
+~ Hyperledger Indy VDR (for "Verifiable Data Registry") is an open source implementation of an Indy client/resolver for both DIDs and other Indy objects.
+The repository is called indy-vdr and can be found [here](https://github.com/hyperledger/indy-vdr).

--- a/spec/8_other_indy_ledger_object_identifiers.md
+++ b/spec/8_other_indy_ledger_object_identifiers.md
@@ -83,11 +83,8 @@ Existing Identifier: `5:5nDyJVP1NrcPAttP3xwMB9:4:5nDyJVP1NrcPAttP3xwMB9:3:CL:564
 
 #### ATTRIB
 
-DID URL: [`did:indy:sovrin:5nDyJVP1NrcPAttP3xwMB9/ATTRIB/<raw>`](https://indyscan.io/tx/SOVRIN_MAINNET/domain/54743), where `<raw>` is the name of the JSON object that is the value of the `raw` [[ref: ATTRIB]] value. In the example linked at the start of this paragraph, the `<raw>` value would be `endpoint`.
-
-Response: Same as the Indy Node [GET_ATTRIB Txn](https://hyperledger-indy.readthedocs.io/projects/node/en/latest/requests.html#get-attrib). Only the `raw` parameter form of the transaction is supported.
-
-Existing Identifier: `F72i3Y3Q4i466efjYJYCHM:1:b6bf...d9e`
-
-- `1` is the enumerated object type
-- `b6bf...d9e` is an identifier for the [[ref: ATTRIB]], likely a hash of the content
+No DID URL representation is defined for the Hyperledger Indy ATTRIB object, as
+the use of the ATTRIB object is **deprecated** with the introduction of the
+`did:indy` DID Method. Where an ATTRIB might have been used in the past, an Indy
+client updated for `did:indy` should put the required data directly into the
+`diddocContent` item in a DID (NYM) update transaction.


### PR DESCRIPTION
Per discussion of WG call -- 20220208, add note about ATTRIB deprecation, and that it will not have a URL format.
