### PR TITLE
verificationMethod and authentication must be arrays

### DIFF
--- a/spec/10_did_operations.md
+++ b/spec/10_did_operations.md
@@ -32,7 +32,7 @@ When using the old Indy SDK convention of using the first 16 bytes of the verkey
 
 The DIDDoc returned when a `did:indy` DID is resolved is not directly stored in an Indy ledger document. Instead, the DIDDoc must be assembled from data elements in the Indy `NYM` object based on a series of steps. When a [[ref: NYM]] is created or updated the ledger MUST assemble the DIDDoc (following the steps) and validate the DIDDoc. As well, an Indy DID resolver will receive from the ledger the [[ref: NYM]] from the ledger and the non-validation steps must be followed to assemble the DIDDoc for the resolved DID.
 
-Since the assembly validation may change between writing the DID and resolving it (notably, step 3.2), a client resolving a DID need SHOULD NOT perform the validation steps.
+Since the assembly validation may change between writing the DID and resolving it (notably, step 3.2), a client resolving a DID SHOULD NOT perform the validation steps.
 
 #### DIDDoc Assembly Steps
 
@@ -43,13 +43,12 @@ The following are the steps for assembling a DIDDoc from its inputs.
 2. The Indy network instance `namespace`, the [[ref: NYM]] `dest` and the [[ref: NYM]] `verkey` items are merged into a text template to produce a base DIDDoc.
     1. See the template in the [Base DIDDoc Template](#base-diddoc-template) section of this document.
     2. If there is no `diddocContent` item in the [[ref: NYM]], assembly is complete; return the DIDDoc and a success status.
-3. If the `diddocContent` item is included in the [[ref: NYM]] is verified and merged into the DIDDoc.
+3. If the `diddocContent` item is included in the [[ref: NYM]], it is verified and merged into the DIDDoc.
     1. The `diddocContent` item MUST NOT have an `id` item. If found, exit the assembly process, returning an error.
     2. If the `diddocContent` item contains a `@context` item, the DIDDoc is assumed to be JSON-LD, and the `@context` element MUST include the current DID Core JSON-LD context. If it does not, exit the assmebly process and return an error.
-    3. If the `diddocContent` item contains `verificationMethod` and/or `authentication` items, process them as follows.
-        1. The entries MUST NOT have the same `id` values as those from the [[ref: NYM]]-generated DIDDoc. If a matching `id` is found, exit and return an error.
-        2. Merge the entries into the respective arrays of DIDDoc.
-    4. Add the other items of the `diddocContent` to the DIDDoc.
+    3. The `diddocContent` MUST NOT contain an item with the same `id` values as those from the [[ref: NYM]]-generated DIDDoc. If a matching `id` is found, exit and return an error.
+    4. If the `diddocContent` item contains `verificationMethod` and/or `authentication` items, these MUST be arrays. Merge the entries into the respective arrays of the DIDDoc.
+    5. Add the other items of the `diddocContent` to the DIDDoc.
 4. The resulting DIDDoc text must be valid JSON. If not JSON, exit and return an error.
 5. The resulting JSON must be a valid DIDDoc. Perform a `<to be determined>` validation process. If not a DIDDoc, exit and return an error.
 ::: warning is this the correct process name


### PR DESCRIPTION
I've changed the DIDDoc building/verification steps a bit. The `id`s of the base did doc must not be present in any of the diddocContent elements not only in `verificationMethod` and `authentication`.

An example would be:

```
"diddocContent": {
"assertionMethod": [
    "did:example:123456789abcdefghi#keys-1",
    {
      "id": "did:example:123456789abcdefghi#verkey",
      "type": "Ed25519VerificationKey2020", 
      "controller": "did:example:123456789abcdefghi",
      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
    }
  ],
}
```

where the same `id` would be redefined in an `assertionMethod` block.

Resolves #47

Signed-off-by: Dominic Wörner <dom.woe@gmail.com>