### PR TITLE
Remove rocket chat reference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,5 +40,5 @@ An alternative way to contribute to the specification, without any local install
 ## Community Links
 
 - [Meeting Agendas and Notes](https://wiki.hyperledger.org/display/indy/Indy+DID+Method+Specification)
-- [Hyperledger Rocketchat #indy-did-method](https://chat.hyperledger.org/channel/indy-did-method)
+- [Hyperledger Discord](https://discord.gg/hyperledger)
   


### PR DESCRIPTION
Signed-off-by: Ry Jones <ry@linux.com>